### PR TITLE
added google calendar event fetcher for POC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+credentials.ini

--- a/google_calendar_fetcher.py
+++ b/google_calendar_fetcher.py
@@ -5,11 +5,10 @@ from googleapiclient.discovery import build
 
 # google calendar event fetcher for poc
 def google_calendar_fetcher():
-    api_version = 'v3'
-    calendar_id = 'ssek01group1kusakaripoc@gmail.com'
     # read api key
     config = configparser.ConfigParser()
     config.read('credentials.ini')
+    calendar_id = config.get('credentials', 'calendar_id')
     api_key = config.get('credentials', 'google_api_key')
 
     # get events 2 weeks ahead in JST
@@ -18,6 +17,7 @@ def google_calendar_fetcher():
     event_end = (datetime.now(JST) + timedelta(weeks=2)).isoformat()
 
     # event fetch
+    api_version = 'v3'
     service = build('calendar', api_version, developerKey=api_key)
     events = service.events().list(
         calendarId=calendar_id,

--- a/google_calendar_fetcher.py
+++ b/google_calendar_fetcher.py
@@ -1,9 +1,42 @@
-
+import configparser
+from datetime import datetime, timedelta, timezone
 from googleapiclient.discovery import build
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
 
-# 各種 Google Calendar APIの依存関係 を import できたことを確認
-Request
-InstalledAppFlow
-build
+
+# google calendar event fetcher for poc
+def google_calendar_fetcher():
+    api_version = 'v3'
+    calendar_id = 'ssek01group1kusakaripoc@gmail.com'
+    # read api key
+    config = configparser.ConfigParser()
+    config.read('credentials.ini')
+    api_key = config.get('credentials', 'google_api_key')
+
+    # get events 2 weeks ahead in JST
+    JST = timezone(timedelta(hours=+9))
+    event_start = datetime.now(JST).isoformat()
+    event_end = (datetime.now(JST) + timedelta(weeks=2)).isoformat()
+
+    # event fetch
+    service = build('calendar', api_version, developerKey=api_key)
+    events = service.events().list(
+        calendarId=calendar_id,
+        timeMin=event_start,
+        timeMax=event_end,
+        singleEvents=True,
+        orderBy='startTime'
+    ).execute().get('items', [])
+
+    if not events:
+        print('2週間以内のイベントは見つかりませんでした。')
+    else:
+        print('2週間以内のイベント:')
+        for event in events:
+            start = event['start'].get('dateTime', event['start'].get('date'))
+            end = event['end'].get('dateTime', event['end'].get('date'))
+            summary = event['summary']
+            print(f'{start} - {end}: {summary}')
+
+
+if __name__ == '__main__':
+    google_calendar_fetcher()


### PR DESCRIPTION
# Background
ユーザストーリーマップで記載していた `Google Calendar APIとの連携`というタスクになります。
この段階では 草刈り候補日の提示の前に、Google Calendar API でイベントがどのように取得できるか調査しました。

# Link
https://miro.com/app/board/uXjVMAJL7hI=/